### PR TITLE
Fix calculation of padded name length for compound datatype members

### DIFF
--- a/pyfive/datatype_msg.py
+++ b/pyfive/datatype_msg.py
@@ -112,7 +112,7 @@ class DatatypeMessage(object):
         members = []
         for _ in range(n_comp):
             null_location = self.buf.index(b'\x00', self.offset)
-            name_size = _padded_size(null_location - self.offset, 8)
+            name_size = _padded_size(null_location - self.offset + 1, 8)
             name = self.buf[self.offset:self.offset+name_size]
             name = name.strip(b'\x00').decode('utf-8')
             self.offset += name_size


### PR DESCRIPTION

<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes PyActiveStorage better and what problem it solves.

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

When reading the names of members of the compound datatype, the calculated name string length has an off-by-one error (doesn't take into account the terminating null character), and so the padded length will incorrectly calculated if the name string (without the null) is a mutiple of 8.

**Note**
This change won't make any difference in the current operation, since the only type of compound dataset that is handled is the special case of complex numbers where the names of the members are 'r' and 'i' for real and imaginary, which won't be affected by this bug.  This bug would only be exposed if more general handling for compound types was implemented in pyfive.

## Before you get started

- [ ] [☝ Create an issue](https://github.com/NCAS-CMS/pyfive/issues) to discuss what you are going to do

_I didn't create an issue, because it would say the same thing as above, and it's a 3-character fix_

## Checklist

- [ ] This pull request has a descriptive title and labels
- [ ] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- [ ] Unit tests have been added (if codecov test fails)
- [ ] Any changed dependencies have been added or removed correctly (if need be)
- [ ] If you are working on the documentation, please ensure the [current build](https://app.readthedocs.org/projects/pyfive/builds/) passes
- [ ] All tests pass
