### PR TITLE
add joss paper pdf conversion via gha

### DIFF
--- a/.github/workflows/joss-draft-pdf.yml
+++ b/.github/workflows/joss-draft-pdf.yml
@@ -1,0 +1,34 @@
+# This GHA runs the compiler for our JOSS paper draft
+# this action will also live temporarily in the main branch
+# so that we can actually run it on the joss_paper branch, but it will be
+# decativated on main, and it will run only on joss_paper branch, triggered by push
+
+---
+name: JOSS Draft PDF
+on:
+  push:
+    branches:
+      - main  # this will be deactivated after a first (unsuccessful) run
+      - joss_paper
+
+jobs:
+  paper:
+    runs-on: ubuntu-latest
+    name: Paper Draft
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build draft PDF
+        uses: openjournals/openjournals-draft-action@master
+        with:
+          journal: joss
+          # This should be the path to the paper within your repo.
+          paper-path: paper.md
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: paper
+          # This is the output path where Pandoc will write the compiled
+          # PDF. Note, this should be the same directory as the input
+          # paper.md
+          path: paper.pdf


### PR DESCRIPTION
Adding Github Action-based JOSS paper compiler. I need to merge this in `main` so that the GHA can be initialized; I will then deactivate the run of this GHA on `main` via the `on:` setter, and it will only run on the `joss_paper` branch, triggered by a push on that branch.