### PR TITLE
add dataobjects.dtype to DatasetMeta

### DIFF
--- a/pyfive/h5d.py
+++ b/pyfive/h5d.py
@@ -593,6 +593,7 @@ class DatasetMeta:
         self.fletcher32 = dataobject.fletcher32
         self.fillvalue = dataobject.fillvalue
         self.attributes = dataobject.get_attributes()
+        self.datatype = dataobject.dtype
 
         #horrible kludge for now, this isn't really the same sort of thing
         #https://github.com/NCAS-CMS/pyfive/issues/13#issuecomment-2557121461


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes PyActiveStorage better and what problem it solves.

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

This will help downstream packages to retrieve the H5 datatype of the Dataset. Needed for `h5netcdf`/`Pyfive` integration.

Closes #111 

## Before you get started

- [x] [☝ Create an issue](https://github.com/NCAS-CMS/pyfive/issues) to discuss what you are going to do

## Checklist

- [x] This pull request has a descriptive title and labels
- [x] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- [ ] Unit tests have been added (if codecov test fails)
- [ ] Any changed dependencies have been added or removed correctly (if need be)
- [ ] If you are working on the documentation, please ensure the [current build](https://app.readthedocs.org/projects/pyfive/builds/) passes
- [x] All tests pass
