### PR TITLE
Switch to miniforge3 in ReadTheDocs build config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,8 +9,7 @@ version: 2
 build:
   os: ubuntu-lts-latest
   tools:
-    # DO NOT use mambaforge-*; that is currently sunsetted
-    python: "miniconda-latest"
+    python: "miniforge3-latest"
   jobs:
     post_create_environment:
       - conda run -n ${CONDA_DEFAULT_ENV} pip install . --no-deps


### PR DESCRIPTION
<!--
    Thank you for contributing to our project!

    Please do not delete this text completely, but read the text below and keep
    items that seem relevant. If in doubt, just keep everything and add your
    own text at the top, a reviewer will update the checklist for you.

-->

## Description

<!--
    Please describe your changes here, especially focusing on why this pull
    request makes PyActiveStorage better and what problem it solves.

    Please fill in the GitHub issue that is closed by this pull request,
    e.g. Closes #1903
-->

Closes #245 

@davidhassell you should do the same for your xnetcdf RTD build, miniconda is now deactivated at RTD


## Before you get started

- [x] [☝ Create an issue](https://github.com/NCAS-CMS/pyfive/issues) to discuss what you are going to do

## Checklist

- [x] This pull request has a descriptive title and labels
- [x] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- [ ] Unit tests have been added (if codecov test fails)
- [x] Any changed dependencies have been added or removed correctly (if need be)
- [x] If you are working on the documentation, please ensure the [current build](https://app.readthedocs.org/projects/pyfive/builds/) passes
- [x] All tests pass
