### PR TITLE
[WIP] Added max_block and request_batch to pyfive.File and backend

### DIFF
--- a/doc/optimising.rst
+++ b/doc/optimising.rst
@@ -86,6 +86,28 @@ For example, you can use the `concurrent.futures` module to read data from multi
 
 You can do the same thing to parallelise manipulations within the variables, by for example using, ``dask``, but that is beyond the scope of this document.
 
+In addition, you can use the attributes ``max_request_block`` and ``batch_request_size`` to customise how requests are made to remote servers in the pyfive backend.
+
+.. code-block:: python
+
+    import pyfive
+
+    var_name = "var1"
+    max_request_block = 10e6 # 10 MB
+    batch_request_size = 80
+
+    with pyfive.File("data.h5", "r", 
+            max_request_block=max_request_block, 
+            batch_request_size=batch_request_size) as f:
+
+        dset = f[var_name]
+        data = dset[...]  # Read the entire variable
+        print('Min: ',data.min())
+
+The ``batch_request_size`` specifies the number of individual requests that can be made asynchronously in parallel by the backend session. Some remote services providing data access have limits applied to the rate of requests, such that if you attempt to make more than a certain number of requests simultaneously (or if you have more than that number of open/pending requests) you may be denied further requests with a ``HTTP 429: Too Many Requests`` error. If you encounter this problem, it may be effective to simply limit the requests your own client can make concurrently.
+
+In addition to the above limit, it may be more efficient for you to make fewer requests in general as each request will require some time for handling on the server end. If you use the ``max_request_block`` parameter, the backend part of the pyfive client will attempt to combine requests that represent a continuous block of memory, so instead of making many requests you can just make one larger request and reduce the overheads. Range-requests will be combined up to the limit you set here (10 Megabytes in the example above). For maximum efficiency, consider the bandwidth available to you, in relation to the maximum request size and the number of concurrent requests. The above example of 80 requests at 10MB per request, when combined with a typical non-fibre bandwidth of 30 Mbps would mean the whole batch would take 200 seconds which may be more than the timeout limit for the session, so you may want to reduce the number of requests or the block size for your situation.
+
 
 Using pyfive with S3
 --------------------

--- a/pyfive/h5d.py
+++ b/pyfive/h5d.py
@@ -229,6 +229,7 @@ class ChunkRead:
         stops = [si.byte_offset + si.size for _, _, _, si in chunks]
 
         paths = [actual_fh.path] * len(chunks)
+        chunk_ranges = list(zip(paths, starts, stops))
         if max_block is not None:
             paths, starts, stops = futils.merge_offset_ranges(
                 paths, starts, stops, max_block=max_block
@@ -236,8 +237,25 @@ class ChunkRead:
 
         buffers = actual_fh.fs.cat_ranges(paths, starts, stops, batch_size=batch_size)
 
+        chunk_buffers = []
+        for path, start, stop in chunk_ranges:
+            for merged_path, merged_start, merged_stop, buffer in zip(
+                paths, starts, stops, buffers
+            ):
+                if (
+                    path == merged_path
+                    and merged_start <= start
+                    and stop <= merged_stop
+                ):
+                    chunk_buffers.append(
+                        buffer[start - merged_start : stop - merged_start]
+                    )
+                    break
+            else:
+                raise RuntimeError("Merged range does not contain requested chunk")
+
         for (_coords, chunk_sel, out_sel, storeinfo), chunk_buffer in zip(
-            chunks, buffers
+            chunks, chunk_buffers
         ):
             out[out_sel] = self._decode_chunk(
                 chunk_buffer, storeinfo.filter_mask, dtype

--- a/pyfive/h5d.py
+++ b/pyfive/h5d.py
@@ -112,7 +112,14 @@ class ChunkRead:
             self.chunks, order=self._order
         )
 
-    def _select_chunks(self, indexer, out, dtype, max_block: int | None = None, batch_size: int | None = None):
+    def _select_chunks(
+        self,
+        indexer,
+        out,
+        dtype,
+        max_block: int | None = None,
+        batch_size: int | None = None,
+    ):
         """
         Collect required chunks and dispatch I/O to the best strategy.
         Called by ``_get_selection_via_chunks`` in place of the serial loop.
@@ -122,18 +129,20 @@ class ChunkRead:
             return
 
         # Case A: fsspec - bulk parallel fetch via cat_ranges
-        if not self.posix and self._cat_range_allowed:
-            fh = self._fh
+        if not self.posix and self._cat_range_allowed:  # type: ignore[attr-defined]
+            fh = self._fh  # type: ignore[attr-defined]
             actual_fh = getattr(fh, "fh", fh)  # support wrapped file-like objects
             if hasattr(actual_fh, "fs") and hasattr(actual_fh.fs, "cat_ranges"):
                 logger.info(
                     f"[pyfive] chunk read strategy: fsspec_cat_ranges ({len(chunks)} chunks)"
                 )
-                self._read_bulk_fsspec(fh, chunks, out, dtype, max_block=max_block, batch_size=batch_size)
+                self._read_bulk_fsspec(
+                    fh, chunks, out, dtype, max_block=max_block, batch_size=batch_size
+                )
                 return
 
         # Case B: POSIX - thread-parallel reads via os.pread
-        if self.posix and hasattr(os, "pread") and self._thread_count != 0:
+        if self.posix and hasattr(os, "pread") and self._thread_count != 0:  # type: ignore[attr-defined]
             logger.info(
                 "[pyfive] chunk read strategy: posix_pread_threads workers=%s (%d chunks)",
                 self._thread_count,
@@ -198,7 +207,15 @@ class ChunkRead:
                 chunk_sel
             ]
 
-    def _read_bulk_fsspec(self, fh, chunks, out, dtype, max_block: int | None = None, batch_size: int | None = None):
+    def _read_bulk_fsspec(
+        self,
+        fh,
+        chunks,
+        out,
+        dtype,
+        max_block: int | None = None,
+        batch_size: int | None = None,
+    ):
         """
         Bulk read via ``fsspec`` ``cat_ranges``.
 
@@ -213,7 +230,9 @@ class ChunkRead:
 
         paths = [actual_fh.path] * len(chunks)
         if max_block is not None:
-            paths, starts, stops = futils.merge_offset_ranges(paths, starts, stops, max_block=max_block)
+            paths, starts, stops = futils.merge_offset_ranges(
+                paths, starts, stops, max_block=max_block
+            )
 
         buffers = actual_fh.fs.cat_ranges(paths, starts, stops, batch_size=batch_size)
 
@@ -939,7 +958,13 @@ class DatasetID(ChunkRead):
                 fh.close()
 
         else:
-            self._select_chunks(indexer, out, dtype, max_block=self._max_block, batch_size=self._batch_size)
+            self._select_chunks(
+                indexer,
+                out,
+                dtype,
+                max_block=self._max_block,
+                batch_size=self._batch_size,
+            )
 
         if isinstance(self._ptype, P5ReferenceType):
             to_reference = np.vectorize(Reference)

--- a/pyfive/h5d.py
+++ b/pyfive/h5d.py
@@ -1,4 +1,5 @@
 import numpy as np
+import fsspec.utils as futils
 from collections import namedtuple
 from operator import mul
 from pyfive.indexing import OrthogonalIndexer, ZarrArrayStub
@@ -111,7 +112,7 @@ class ChunkRead:
             self.chunks, order=self._order
         )
 
-    def _select_chunks(self, indexer, out, dtype):
+    def _select_chunks(self, indexer, out, dtype, max_block: int | None = None, batch_size: int | None = None):
         """
         Collect required chunks and dispatch I/O to the best strategy.
         Called by ``_get_selection_via_chunks`` in place of the serial loop.
@@ -128,7 +129,7 @@ class ChunkRead:
                 logger.info(
                     f"[pyfive] chunk read strategy: fsspec_cat_ranges ({len(chunks)} chunks)"
                 )
-                self._read_bulk_fsspec(fh, chunks, out, dtype)
+                self._read_bulk_fsspec(fh, chunks, out, dtype, max_block=max_block, batch_size=batch_size)
                 return
 
         # Case B: POSIX - thread-parallel reads via os.pread
@@ -197,7 +198,7 @@ class ChunkRead:
                 chunk_sel
             ]
 
-    def _read_bulk_fsspec(self, fh, chunks, out, dtype):
+    def _read_bulk_fsspec(self, fh, chunks, out, dtype, max_block: int | None = None, batch_size: int | None = None):
         """
         Bulk read via ``fsspec`` ``cat_ranges``.
 
@@ -207,10 +208,14 @@ class ChunkRead:
         (reaching through the MetadataBufferingWrapper).
         """
         actual_fh = getattr(fh, "fh", fh)  # support wrapped file-like objects
-        path = actual_fh.path
         starts = [si.byte_offset for _, _, _, si in chunks]
         stops = [si.byte_offset + si.size for _, _, _, si in chunks]
-        buffers = actual_fh.fs.cat_ranges([path] * len(chunks), starts, stops)
+
+        paths = [actual_fh.path] * len(chunks)
+        if max_block is not None:
+            paths, starts, stops = futils.merge_offset_ranges(paths, starts, stops, max_block=max_block)
+
+        buffers = actual_fh.fs.cat_ranges(paths, starts, stops, batch_size=batch_size)
 
         for (_coords, chunk_sel, out_sel, storeinfo), chunk_buffer in zip(
             chunks, buffers
@@ -240,6 +245,8 @@ class DatasetID(ChunkRead):
         dataobject: "DataObjects",  # type: ignore[name-defined]  # noqa: F821
         noindex: bool = False,
         pseudo_chunking_size_MB: int = 4,
+        max_request_block: int | None = None,
+        batch_request_size: int | None = None,
     ) -> None:
         """
         Instantiated with the ``pyfive`` ``datasetdataobject``, we copy and cache everything
@@ -262,6 +269,9 @@ class DatasetID(ChunkRead):
         it.)
 
         """
+
+        self._max_block = max_request_block
+        self._batch_size = batch_request_size
 
         self._order = dataobject.order
         fh = dataobject.fh
@@ -929,7 +939,7 @@ class DatasetID(ChunkRead):
                 fh.close()
 
         else:
-            self._select_chunks(indexer, out, dtype)
+            self._select_chunks(indexer, out, dtype, max_block=self._max_block, batch_size=self._batch_size)
 
         if isinstance(self._ptype, P5ReferenceType):
             to_reference = np.vectorize(Reference)

--- a/pyfive/high_level.py
+++ b/pyfive/high_level.py
@@ -41,13 +41,13 @@ class Group(Mapping):
     """
 
     def __init__(
-            self,
-            name: str,
-            dataobjects: DataObjects,
-            parent: "Group",
-            max_request_block: int | None = None,
-            batch_request_size: int | None = None
-        ) -> None:
+        self,
+        name: str,
+        dataobjects: DataObjects,
+        parent: "Group",
+        max_request_block: int | None = None,
+        batch_request_size: int | None = None,
+    ) -> None:
         """initalize."""
 
         self.parent = parent
@@ -150,10 +150,13 @@ class Group(Mapping):
             return Dataset(
                 obj_name,
                 DatasetID(
-                    dataobjs, noindex=noindex,
+                    dataobjs,
+                    noindex=noindex,
                     max_request_block=self._max_request_block,
-                    batch_request_size=self._batch_request_size)
-                , self)
+                    batch_request_size=self._batch_request_size,
+                ),
+                self,
+            )
 
         try:
             # if true, this may well raise a NotImplementedError, if so, we need
@@ -276,7 +279,7 @@ class File(Group):
         filename: str | BinaryIO | MetadataBufferingWrapper,
         mode: str = "r",
         metadata_buffer_size: int = 1,
-        **kwargs
+        **kwargs,
     ) -> None:
         """initalize."""
 

--- a/pyfive/high_level.py
+++ b/pyfive/high_level.py
@@ -40,7 +40,14 @@ class Group(Mapping):
 
     """
 
-    def __init__(self, name: str, dataobjects: DataObjects, parent: "Group") -> None:
+    def __init__(
+            self,
+            name: str,
+            dataobjects: DataObjects,
+            parent: "Group",
+            max_request_block: int | None = None,
+            batch_request_size: int | None = None
+        ) -> None:
         """initalize."""
 
         self.parent = parent
@@ -50,6 +57,9 @@ class Group(Mapping):
         self._links = dataobjects.get_links()
         self._dataobjects = dataobjects
         self._attrs = None  # cached property
+
+        self._max_request_block = max_request_block
+        self._batch_request_size = batch_request_size
 
     def __repr__(self):
         return '<HDF5 group "%s" (%d members)>' % (self.name, len(self))
@@ -137,7 +147,13 @@ class Group(Mapping):
         if dataobjs.is_dataset:
             if additional_obj != ".":
                 raise KeyError("%s is a dataset, not a group" % (obj_name))
-            return Dataset(obj_name, DatasetID(dataobjs, noindex=noindex), self)
+            return Dataset(
+                obj_name,
+                DatasetID(
+                    dataobjs, noindex=noindex,
+                    max_request_block=self._max_request_block,
+                    batch_request_size=self._batch_request_size)
+                , self)
 
         try:
             # if true, this may well raise a NotImplementedError, if so, we need
@@ -260,8 +276,10 @@ class File(Group):
         filename: str | BinaryIO | MetadataBufferingWrapper,
         mode: str = "r",
         metadata_buffer_size: int = 1,
+        **kwargs
     ) -> None:
         """initalize."""
+
         if mode != "r":
             raise NotImplementedError(
                 "pyfive only provides support for reading and treats all reads as binary"
@@ -306,7 +324,7 @@ class File(Group):
         self.file = self
         self.mode = "r"
         self.userblock_size = 0
-        super(File, self).__init__("/", dataobjects, self)
+        super(File, self).__init__("/", dataobjects, self, **kwargs)
 
     @property
     def consolidated_metadata(self) -> bool:

--- a/tests/test_btree_parallel.py
+++ b/tests/test_btree_parallel.py
@@ -273,28 +273,22 @@ def test_parallel_fsspec_cat_ranges_matches_serial_results():
     standard_calls = list(calls)
     calls = []
 
-    client_kwargs = {"auth": None, "ssl": False}
-    fs = fsspec.filesystem("http", **client_kwargs)
+    with memfs.open(mem_path, "rb") as fh:
+        with pyfive.File(
+            fh, max_request_block=10_000_000, batch_request_size=100
+        ) as hfile:
+            ds = hfile["dataset1"]
+            merged_data = ds[:]
+            merged_chunk_info = [
+                ds.id.get_chunk_info(i) for i in range(ds.id.get_num_chunks())
+            ]
 
-    original_cat_ranges = fs.cat_ranges
-    fs.cat_ranges = cat_ranges_spy
-
-    uri = "https://esgf.ceda.ac.uk/thredds/fileServer/esg_cmip6/CMIP6/AerChemMIP/MOHC/UKESM1-0-LL/ssp370SST-lowNTCF/r1i1p1f2/Amon/cl/gn/latest/cl_Amon_UKESM1-0-LL_ssp370SST-lowNTCF_r1i1p1f2_gn_205001-209912.nc"
-
-    with fs.open(uri, "rb") as fh:
-        with pyfive.File(fh, max_request_block=10e6, batch_request_size=100) as hfile:
-            ds = np.array(hfile["cl"][:100])
-            assert ds.shape == (100, 85, 144, 192)
-
-    assert len(calls[0][0]) > 0, (
-        "Expected fsspec cat_ranges to be used for leaf-node reads"
-    )
-    assert len(standard_calls[0][0]) > 0, (
-        "Expected fsspec cat_ranges to be used for leaf-node reads"
-    )
-    assert len(calls[0][0]) != len(standard_calls[0][0]), (
-        "Expected differing cat_range spans"
-    )
+    assert calls, "Expected fsspec cat_ranges to be used for merged range reads"
+    assert_array_equal(merged_data, serial_data)
+    assert merged_chunk_info == serial_chunk_info
+    assert sum(len(paths) for paths, _, _ in calls) < sum(
+        len(paths) for paths, _, _ in standard_calls
+    ), "Expected max_request_block to reduce the number of cat_range spans"
 
 
 def test_parallel_s3fs_cat_ranges_matches_serial_results(s3fs_s3):

--- a/tests/test_btree_parallel.py
+++ b/tests/test_btree_parallel.py
@@ -286,13 +286,15 @@ def test_parallel_fsspec_cat_ranges_matches_serial_results():
             ds = np.array(hfile["cl"][:100])
             assert ds.shape == (100, 85, 144, 192)
 
-    assert len(calls[0]) > 0, (
+    assert len(calls[0][0]) > 0, (
         "Expected fsspec cat_ranges to be used for leaf-node reads"
     )
-    assert len(standard_calls[0]) > 0, (
+    assert len(standard_calls[0][0]) > 0, (
         "Expected fsspec cat_ranges to be used for leaf-node reads"
     )
-    assert len(calls[0]) != len(standard_calls[0]), "Expected differing cat_range spans"
+    assert len(calls[0][0]) != len(standard_calls[0][0]), (
+        "Expected differing cat_range spans"
+    )
 
 
 def test_parallel_s3fs_cat_ranges_matches_serial_results(s3fs_s3):

--- a/tests/test_btree_parallel.py
+++ b/tests/test_btree_parallel.py
@@ -273,7 +273,7 @@ def test_parallel_fsspec_cat_ranges_matches_serial_results():
     calls = []
 
     with memfs.open(mem_path, "rb") as fh:
-        with pyfive.File(fh, max_request_block=10e6, batch_size=100) as hfile:
+        with pyfive.File(fh, max_request_block=10e6, batch_request_size=100) as hfile:
             ds = hfile["dataset1"]
             ds.id.set_parallelism(
                 thread_count=0, cat_range_allowed=True, btree_parallel=True

--- a/tests/test_btree_parallel.py
+++ b/tests/test_btree_parallel.py
@@ -4,6 +4,7 @@ import struct
 
 import fsspec
 import pytest
+import numpy as np
 from numpy.testing import assert_array_equal
 
 import pyfive
@@ -272,16 +273,18 @@ def test_parallel_fsspec_cat_ranges_matches_serial_results():
     standard_calls = list(calls)
     calls = []
 
-    with memfs.open(mem_path, "rb") as fh:
+    client_kwargs = {"auth": None, "ssl": False}
+    fs = fsspec.filesystem("http", **client_kwargs)
+
+    original_cat_ranges = fs.cat_ranges
+    fs.cat_ranges = cat_ranges_spy
+
+    uri = "https://esgf.ceda.ac.uk/thredds/fileServer/esg_cmip6/CMIP6/AerChemMIP/MOHC/UKESM1-0-LL/ssp370SST-lowNTCF/r1i1p1f2/Amon/cl/gn/latest/cl_Amon_UKESM1-0-LL_ssp370SST-lowNTCF_r1i1p1f2_gn_205001-209912.nc"
+
+    with fs.open(uri, "rb") as fh:
         with pyfive.File(fh, max_request_block=10e6, batch_request_size=100) as hfile:
-            ds = hfile["dataset1"]
-            ds.id.set_parallelism(
-                thread_count=0, cat_range_allowed=True, btree_parallel=True
-            )
-            fsspec_data = ds[:]
-            fsspec_chunk_info = [
-                ds.id.get_chunk_info(i) for i in range(ds.id.get_num_chunks())
-            ]
+            ds = np.array(hfile["cl"][:100])
+            assert ds.shape == (100, 85, 144, 192)
 
     assert len(calls[0]) > 0, (
         "Expected fsspec cat_ranges to be used for leaf-node reads"

--- a/tests/test_btree_parallel.py
+++ b/tests/test_btree_parallel.py
@@ -269,6 +269,28 @@ def test_parallel_fsspec_cat_ranges_matches_serial_results():
     assert_array_equal(fsspec_data, serial_data)
     assert fsspec_chunk_info == serial_chunk_info
 
+    standard_calls = list(calls)
+    calls = []
+
+    with memfs.open(mem_path, "rb") as fh:
+        with pyfive.File(fh, max_request_block=10e6, batch_size=100) as hfile:
+            ds = hfile["dataset1"]
+            ds.id.set_parallelism(
+                thread_count=0, cat_range_allowed=True, btree_parallel=True
+            )
+            fsspec_data = ds[:]
+            fsspec_chunk_info = [
+                ds.id.get_chunk_info(i) for i in range(ds.id.get_num_chunks())
+            ]
+
+    assert len(calls[0]) > 0, (
+        "Expected fsspec cat_ranges to be used for leaf-node reads"
+    )
+    assert len(standard_calls[0]) > 0, (
+        "Expected fsspec cat_ranges to be used for leaf-node reads"
+    )
+    assert len(calls[0]) != len(standard_calls[0]), "Expected differing cat_range spans"
+
 
 def test_parallel_s3fs_cat_ranges_matches_serial_results(s3fs_s3):
     with pyfive.File(DATASET_CHUNKED_HDF5_FILE) as hfile:

--- a/tests/test_h5d.py
+++ b/tests/test_h5d.py
@@ -99,7 +99,13 @@ def test_max_block():
     Test the max_block parameter which invokes an
     fsspec utility function.
     """
-    with pyfive.File(str(filename), max_request_block=10e6) as g:
+    import fsspec
+
+    client_kwargs = {"auth": None, "ssl": False}
+    fs = fsspec.filesystem("http", **client_kwargs)
+    http_file = fs.open(str(filename), "rb")
+
+    with pyfive.File(http_file, max_request_block=10e6) as g:
         var = g[variable_name]
         assert isinstance(var, pyfive.Dataset)
         # Accessing the data should trigger index building

--- a/tests/test_h5d.py
+++ b/tests/test_h5d.py
@@ -9,6 +9,8 @@ import s3fs
 
 from conftest import s3_url_exists
 
+DIRNAME = os.path.dirname(__file__)
+DATASET_CHUNKED_HDF5_FILE = os.path.join(DIRNAME, "data", "chunked.hdf5")
 
 mypath = Path(__file__).parent
 filename = mypath / "data" / "compressed.hdf5"
@@ -92,36 +94,6 @@ def test_iter_chunks_sel():
             # print(p5chunks,var.shape, var.chunks)
 
         assert h5chunks == p5chunks
-
-
-def test_max_block():
-    """
-    Test the max_block parameter which invokes an
-    fsspec utility function.
-    """
-    import fsspec
-
-    client_kwargs = {"auth": None, "ssl": False}
-    fs = fsspec.filesystem("http", **client_kwargs)
-    http_file = fs.open(str(filename), "rb")
-
-    with pyfive.File(http_file, max_request_block=10e6) as g:
-        var = g[variable_name]
-        assert isinstance(var, pyfive.Dataset)
-        # Accessing the data should trigger index building
-        _ = var[0, 0]
-
-
-def test_batch_size():
-    """
-    Test the max_block parameter which invokes an
-    fsspec utility function.
-    """
-    with pyfive.File(str(filename), batch_request_size=100) as g:
-        var = g[variable_name]
-        assert isinstance(var, pyfive.Dataset)
-        # Accessing the data should trigger index building
-        _ = var[0, 0]
 
 
 def test_chunk_index_logging(caplog):

--- a/tests/test_h5d.py
+++ b/tests/test_h5d.py
@@ -93,6 +93,29 @@ def test_iter_chunks_sel():
 
         assert h5chunks == p5chunks
 
+def test_max_block():
+    """
+    Test the max_block parameter which invokes an
+    fsspec utility function.
+    """
+    with pytest.raises(NotImplementedError):
+        with pyfive.File(str(filename), max_request_block=10e6) as g:
+            var = g[variable_name]
+            assert isinstance(var, pyfive.Dataset)
+            # Accessing the data should trigger index building
+            _ = var[0, 0]
+
+def test_batch_size():
+    """
+    Test the max_block parameter which invokes an
+    fsspec utility function.
+    """
+    with pytest.raises(NotImplementedError):
+        with pyfive.File(str(filename), batch_request_size=100) as g:
+            var = g[variable_name]
+            assert isinstance(var, pyfive.Dataset)
+            # Accessing the data should trigger index building
+            _ = var[0, 0]
 
 def test_chunk_index_logging(caplog):
     """Test that logging.info messages are generated when building chunk index."""

--- a/tests/test_h5d.py
+++ b/tests/test_h5d.py
@@ -93,6 +93,7 @@ def test_iter_chunks_sel():
 
         assert h5chunks == p5chunks
 
+
 def test_max_block():
     """
     Test the max_block parameter which invokes an
@@ -105,6 +106,7 @@ def test_max_block():
             # Accessing the data should trigger index building
             _ = var[0, 0]
 
+
 def test_batch_size():
     """
     Test the max_block parameter which invokes an
@@ -116,6 +118,7 @@ def test_batch_size():
             assert isinstance(var, pyfive.Dataset)
             # Accessing the data should trigger index building
             _ = var[0, 0]
+
 
 def test_chunk_index_logging(caplog):
     """Test that logging.info messages are generated when building chunk index."""

--- a/tests/test_h5d.py
+++ b/tests/test_h5d.py
@@ -99,12 +99,11 @@ def test_max_block():
     Test the max_block parameter which invokes an
     fsspec utility function.
     """
-    with pytest.raises(NotImplementedError):
-        with pyfive.File(str(filename), max_request_block=10e6) as g:
-            var = g[variable_name]
-            assert isinstance(var, pyfive.Dataset)
-            # Accessing the data should trigger index building
-            _ = var[0, 0]
+    with pyfive.File(str(filename), max_request_block=10e6) as g:
+        var = g[variable_name]
+        assert isinstance(var, pyfive.Dataset)
+        # Accessing the data should trigger index building
+        _ = var[0, 0]
 
 
 def test_batch_size():
@@ -112,12 +111,11 @@ def test_batch_size():
     Test the max_block parameter which invokes an
     fsspec utility function.
     """
-    with pytest.raises(NotImplementedError):
-        with pyfive.File(str(filename), batch_request_size=100) as g:
-            var = g[variable_name]
-            assert isinstance(var, pyfive.Dataset)
-            # Accessing the data should trigger index building
-            _ = var[0, 0]
+    with pyfive.File(str(filename), batch_request_size=100) as g:
+        var = g[variable_name]
+        assert isinstance(var, pyfive.Dataset)
+        # Accessing the data should trigger index building
+        _ = var[0, 0]
 
 
 def test_chunk_index_logging(caplog):

--- a/tests/test_h5d.py
+++ b/tests/test_h5d.py
@@ -9,9 +9,6 @@ import s3fs
 
 from conftest import s3_url_exists
 
-DIRNAME = os.path.dirname(__file__)
-DATASET_CHUNKED_HDF5_FILE = os.path.join(DIRNAME, "data", "chunked.hdf5")
-
 mypath = Path(__file__).parent
 filename = mypath / "data" / "compressed.hdf5"
 variable_name = "dataset3"


### PR DESCRIPTION
## Description

- Added `max_block` and `request_batch` as parameters to the pyfive.File declaration. This is relayed to the backend bulk_fsspec method which now uses the merge_requests utility from fsspec if max_block is defined. Request batch allows configuration via the fsspec cat_ranges method to restrict the number of simultaneous requests down from the default for remote connections of 1280.

## Checklist

- [x] This pull request has a descriptive title and labels
- [x] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- [ ] Unit tests have been added (if codecov test fails)
- [x] Any changed dependencies have been added or removed correctly (if need be)
- [ ] If you are working on the documentation, please ensure the [current build](https://app.readthedocs.org/projects/pyfive/builds/) passes
- [ ] All tests pass
