### PR TITLE
Issue252 - dealing with user blocks in front of HDF5 superblocks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: v6.0.0
     hooks:
       - id: check-added-large-files
-        exclude: ^tests/data/cmip_bad_eg\.nc$
+        exclude: ^tests/data/(cmip_bad_eg\.nc|Data_20230106_01_014\.mat)$
       - id: check-ast
       - id: check-case-conflict
       - id: check-merge-conflict

--- a/pyfive/dataobjects.py
+++ b/pyfive/dataobjects.py
@@ -56,7 +56,7 @@ class DataObjects(object):
     HDF5 DataObjects.
     """
 
-    def __init__(self, fh, offset, order="C"):
+    def __init__(self, fh, offset, order="C", decode_strings=False):
         """initalize."""
         # Log file handle info for diagnostics
         fh_id = id(fh)
@@ -96,6 +96,7 @@ class DataObjects(object):
         self._chunk_address = None
         self._cached_attributes = None  # Cache parsed attributes
         self.order = order
+        self.decode_strings = decode_strings
 
     @staticmethod
     def _parse_v1_objects(fh):
@@ -350,7 +351,10 @@ class DataObjects(object):
             for i in range(count):
                 if isinstance(ptype, P5StringType):
                     _, vlen_data = self._vlen_size_and_data(buf, offset)
-                    value[i] = vlen_data.decode("utf-8")
+                    if self.decode_strings and vlen_data is not None:
+                        value[i] = vlen_data.decode(ptype.encoding.lower())
+                    else:
+                        value[i] = vlen_data
                     offset += 16
                 elif isinstance(ptype, P5ReferenceType):
                     (address,) = struct.unpack_from("<Q", buf, offset=offset)

--- a/pyfive/dataobjects.py
+++ b/pyfive/dataobjects.py
@@ -44,6 +44,7 @@ from pyfive.p5t import (
 )
 from pyfive.h5d import DatasetID
 from pyfive.h5py import Empty
+from pyfive.utilities import unwrap_file_handle
 
 # these constants happen to have the same value...
 UNLIMITED_SIZE = UNDEFINED_ADDRESS
@@ -59,9 +60,10 @@ class DataObjects(object):
     def __init__(self, fh, offset, order="C", decode_strings=False):
         """initalize."""
         # Log file handle info for diagnostics
-        fh_id = id(fh)
-        fh_type = type(fh).__name__
-        is_s3 = hasattr(fh, "fs") or "S3" in fh_type
+        actual_fh = unwrap_file_handle(fh)
+        fh_id = id(actual_fh)
+        fh_type = type(actual_fh).__name__
+        is_s3 = hasattr(actual_fh, "fs") or "S3" in fh_type
 
         fh.seek(offset)
         version_hint = struct.unpack_from("<B", fh.read(1))[0]
@@ -215,8 +217,9 @@ class DataObjects(object):
                     " -> ".join(f"{f.function}" for f in pyfive_stack[1:]),
                 )
         if offsets and logger.isEnabledFor(logging.INFO):
-            fh_id = id(self.fh)
-            fh_type = type(self.fh).__name__
+            actual_fh = unwrap_file_handle(self.fh)
+            fh_id = id(actual_fh)
+            fh_type = type(actual_fh).__name__
             logger.info(
                 "[pyfive] Obtained %d%s attributes from offset %d (fh_id=%s type=%s) in %.4fs",
                 len(attrs),

--- a/pyfive/h5d.py
+++ b/pyfive/h5d.py
@@ -53,9 +53,14 @@ class ChunkRead:
             # ideally now everything gets raised immediately on error,
             # but some apparently fsspec backends don't respect on_error,
             # either by not accepting it, or not properly honouring it.
-        except TypeError:
+        except TypeError as e:
             # we need to handle the case of not accepting it
-            buffers = fs.cat_ranges(paths, starts, stops)
+            msg = str(e)
+            if "on_error" in msg and "unexpected keyword" in msg:
+                buffers = fs.cat_ranges(paths, starts, stops)
+            else:
+                # could be something else, so re-raise
+                raise
 
         # and handle the case of not honouring the on_error argument
         for buffer in buffers:

--- a/pyfive/h5d.py
+++ b/pyfive/h5d.py
@@ -45,6 +45,25 @@ class ChunkRead:
     # Shared helpers                                                       #
     # ------------------------------------------------------------------ #
 
+    @staticmethod
+    def _cat_ranges_raise(fs, paths, starts, stops):
+        """Return cat_ranges buffers, raising any read exceptions immediately."""
+        try:
+            buffers = fs.cat_ranges(paths, starts, stops, on_error="raise")
+            # ideally now everything gets raised immediately on error,
+            # but some apparently fsspec backends don't respect on_error,
+            # either by not accepting it, or not properly honouring it.
+        except TypeError:
+            # we need to handle the case of not accepting it
+            buffers = fs.cat_ranges(paths, starts, stops)
+
+        # and handle the case of not honouring the on_error argument
+        for buffer in buffers:
+            if isinstance(buffer, Exception):
+                raise buffer
+
+        return buffers
+
     def set_parallelism(
         self, thread_count=0, cat_range_allowed=True, btree_parallel=False
     ):
@@ -210,7 +229,12 @@ class ChunkRead:
         path = actual_fh.path
         starts = [si.byte_offset for _, _, _, si in chunks]
         stops = [si.byte_offset + si.size for _, _, _, si in chunks]
-        buffers = actual_fh.fs.cat_ranges([path] * len(chunks), starts, stops)
+        buffers = self._cat_ranges_raise(
+            actual_fh.fs,
+            [path] * len(chunks),
+            starts,
+            stops,
+        )
 
         for (_coords, chunk_sel, out_sel, storeinfo), chunk_buffer in zip(
             chunks, buffers
@@ -648,7 +672,12 @@ class DatasetID(ChunkRead):
 
                 def fetch_cat_ranges(addresses, size):
                     stops = [addr + size for addr in addresses]
-                    return fs.cat_ranges([path] * len(addresses), addresses, stops)
+                    return self._cat_ranges_raise(
+                        fs,
+                        [path] * len(addresses),
+                        addresses,
+                        stops,
+                    )
 
                 return fetch_cat_ranges
 

--- a/pyfive/h5d.py
+++ b/pyfive/h5d.py
@@ -325,6 +325,7 @@ class DatasetID(ChunkRead):
         self.shape = dataobject.shape
         self.rank = len(self.shape)
         self.chunks = dataobject.chunks
+        self._decode_strings = dataobject.decode_strings
         self.set_parallelism()
 
         # experimental code. We need to find out whether or not this
@@ -738,6 +739,7 @@ class DatasetID(ChunkRead):
                 self.shape,
                 self._ptype,
                 fillvalue,
+                self._decode_strings,
             )
             if self.posix:
                 fh.close()
@@ -955,6 +957,7 @@ class DatasetID(ChunkRead):
                     global_heaps,
                     chunk_shape,
                     self._ptype,
+                    self._decode_strings,
                 )
                 chunk_data = chunk_data.reshape(chunk_shape)
                 out[out_selection] = chunk_data[chunk_selection]

--- a/pyfive/high_level.py
+++ b/pyfive/high_level.py
@@ -243,6 +243,11 @@ class File(Group):
         Size of metadata buffer for S3/remote files in MiB (default: 1MiB).
         Larger values reduce network calls but use more memory.
         (This is a pyfive extension for optimizing remote file access, ignored for local files.)
+    decode_strings : bool (default False)
+        If False, variable-length strings are returned as bytes like h5py.
+        If True, variable-length strings in dataset data, fill values, and
+        attributes are decoded to Python str objects.
+        (This is a pyfive extension for user convenience.)
 
     Attributes
     ----------
@@ -260,6 +265,7 @@ class File(Group):
         filename: str | BinaryIO | MetadataBufferingWrapper,
         mode: str = "r",
         metadata_buffer_size: int = 1,
+        decode_strings: bool = False,
     ) -> None:
         """initalize."""
         if mode != "r":
@@ -267,6 +273,7 @@ class File(Group):
                 "pyfive only provides support for reading and treats all reads as binary"
             )
         self._close = False
+        self.decode_strings = decode_strings
         if hasattr(filename, "read"):
             if not hasattr(filename, "seek"):
                 raise ValueError("File like object must have a seek method")
@@ -337,7 +344,11 @@ class File(Group):
         cached = self._dataobjects_cache.get(obj_addr)
         if cached is not None:
             return cached
-        dataobjects = DataObjects(self._fh, obj_addr)
+        dataobjects = DataObjects(
+            self._fh,
+            obj_addr,
+            decode_strings=self.decode_strings,
+        )
         self._dataobjects_cache[obj_addr] = dataobjects
         return dataobjects
 

--- a/pyfive/high_level.py
+++ b/pyfive/high_level.py
@@ -311,8 +311,11 @@ class File(Group):
         superblock_offset = self._find_superblock_offset(self._fh)
         initial_superblock = SuperBlock(self._fh, superblock_offset)
         base_address = initial_superblock._contents["base_address"]
-        self._fh = HDF5OffsetWrapper(self._fh, base_address)
-        logical_superblock_offset = superblock_offset - base_address
+        if base_address:
+            self._fh = HDF5OffsetWrapper(self._fh, base_address)
+            logical_superblock_offset = superblock_offset - base_address
+        else:
+            logical_superblock_offset = superblock_offset
         self._superblock = SuperBlock(self._fh, logical_superblock_offset)
         self._dataobjects_cache: dict = {}
         offset = self._superblock.offset_to_dataobjects

--- a/pyfive/high_level.py
+++ b/pyfive/high_level.py
@@ -14,13 +14,16 @@ import numpy as np
 from typing import Any, BinaryIO, cast
 from typing_extensions import Self  # Python 3.10-compat
 from pyfive.core import Reference
+from pyfive.core import InvalidHDF5File
 from pyfive.dataobjects import DataObjects, DatasetID
-from pyfive.misc_low_level import SuperBlock
+from pyfive.misc_low_level import FORMAT_SIGNATURE, SuperBlock
 from pyfive.h5py import Datatype
 from pyfive.p5t import P5VlenStringType, P5ReferenceType, P5SequenceType
-from pyfive.utilities import MetadataBufferingWrapper
+from pyfive.utilities import HDF5OffsetWrapper, MetadataBufferingWrapper
 
 logger = logging.getLogger(__name__)
+
+FileHandle = BinaryIO | MetadataBufferingWrapper | HDF5OffsetWrapper
 
 
 class Group(Mapping):
@@ -256,13 +259,13 @@ class File(Group):
     mode : str
         String indicating that the file is open readonly ("r").
     userblock_size : int
-        Size of the user block in bytes (currently always 0).
+        Size of the user block in bytes before the HDF5 superblock.
 
     """
 
     def __init__(
         self,
-        filename: str | BinaryIO | MetadataBufferingWrapper,
+        filename: str | FileHandle,
         mode: str = "r",
         metadata_buffer_size: int = 1,
         decode_strings: bool = False,
@@ -285,7 +288,7 @@ class File(Group):
             self.filename = filename
 
         # Wrap S3 file handles with metadata buffering to reduce network calls
-        self._fh: BinaryIO | MetadataBufferingWrapper
+        self._fh: FileHandle
         if isinstance(fh, MetadataBufferingWrapper):
             # Already wrapped
             self._fh = fh
@@ -305,15 +308,39 @@ class File(Group):
             # str | BytesIO = MetadataBufferingWrapper
             self._fh = fh
 
-        self._superblock = SuperBlock(self._fh, 0)
+        superblock_offset = self._find_superblock_offset(self._fh)
+        initial_superblock = SuperBlock(self._fh, superblock_offset)
+        base_address = initial_superblock._contents["base_address"]
+        self._fh = HDF5OffsetWrapper(self._fh, base_address)
+        logical_superblock_offset = superblock_offset - base_address
+        self._superblock = SuperBlock(self._fh, logical_superblock_offset)
         self._dataobjects_cache: dict = {}
         offset = self._superblock.offset_to_dataobjects
         dataobjects = self._get_dataobjects(offset)
 
         self.file = self
         self.mode = "r"
-        self.userblock_size = 0
+        self.userblock_size = base_address
         super(File, self).__init__("/", dataobjects, self)
+
+    @staticmethod
+    def _find_superblock_offset(fh: FileHandle) -> int:
+        """Locate the HDF5 signature at the standard superblock offsets."""
+        original_offset = fh.tell()
+        try:
+            fh.seek(0, os.SEEK_END)
+            file_size = fh.tell()
+            offset = 0
+
+            while offset + len(FORMAT_SIGNATURE) <= file_size:
+                fh.seek(offset)
+                if fh.read(len(FORMAT_SIGNATURE)) == FORMAT_SIGNATURE:
+                    return offset
+                offset = 512 if offset == 0 else offset * 2
+        finally:
+            fh.seek(original_offset)
+
+        raise InvalidHDF5File("Unable to locate HDF5 file signature")
 
     @property
     def consolidated_metadata(self) -> bool:

--- a/pyfive/misc_low_level.py
+++ b/pyfive/misc_low_level.py
@@ -536,7 +536,7 @@ class FractalHeap(object):
 
 
 def get_vlen_string_data_contiguous(
-    fh, data_offset, global_heaps, shape, dtype, fillvalue
+    fh, data_offset, global_heaps, shape, dtype, fillvalue, decode_strings=False
 ):
     """Return the data for a variable which is made up of variable length string data"""
     # we need to import this from DatasetID, and that's imported from Dataobjects hence
@@ -570,15 +570,15 @@ def get_vlen_string_data_contiguous(
 
         offset += 16
 
-    # If character_set == 0 ascii character set, return as
-    # bytes. Otherwise return as UTF-8.
-    if dtype.character_set:
-        value = _convert_to_utf8_string_objects(value)
+    if decode_strings:
+        value = _convert_string_objects(value, dtype.encoding.lower())
 
     return value
 
 
-def get_vlen_string_data_from_chunk(fh, data_offset, global_heaps, shape, dtype):
+def get_vlen_string_data_from_chunk(
+    fh, data_offset, global_heaps, shape, dtype, decode_strings=False
+):
     """Return the data for a data chunk which is made up of variable
     length string data.
 
@@ -602,20 +602,15 @@ def get_vlen_string_data_from_chunk(fh, data_offset, global_heaps, shape, dtype)
         value[i] = gheap.objects[gheap_id["object_index"]]
         offset += 16
 
-    # If character_set == 0 ascii character set, return as
-    # bytes. Otherwise return as UTF-8.
-    if dtype.character_set:
-        value = _convert_to_utf8_string_objects(value)
+    if decode_strings:
+        value = _convert_string_objects(value, dtype.encoding.lower())
 
     return value
 
 
-def _convert_to_utf8_string_objects(array):
-    """Convert an numpy array of byte string objects to an array of UTF-8
-    string objects.
-
-    """
-    decode = np.vectorize(lambda x: x.decode("utf-8"))
+def _convert_string_objects(array, encoding):
+    """Convert a numpy object array of bytes to decoded Python strings."""
+    decode = np.vectorize(lambda x: x.decode(encoding) if x is not None else None)
     array = decode(array)
     array = array.astype("O")
     return array

--- a/pyfive/p5t.py
+++ b/pyfive/p5t.py
@@ -148,7 +148,13 @@ class P5VlenStringType(P5StringType):
         super().__init__(character_set)
 
     def _build_dtype(self):
-        return np.dtype("O", metadata={"vlen": str if self.character_set else bytes})
+        return np.dtype(
+            "O",
+            metadata={
+                "vlen": str if self.character_set else bytes,
+                "h5py_encoding": self.encoding.lower(),
+            },
+        )
 
 
 @dataclass

--- a/pyfive/utilities.py
+++ b/pyfive/utilities.py
@@ -7,6 +7,16 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def unwrap_file_handle(fh):
+    """Return the underlying file handle for diagnostics and capability checks."""
+    unwrapped = fh
+    while True:
+        next_fh = getattr(unwrapped, "fh", getattr(unwrapped, "_fh", None))
+        if next_fh is None or next_fh is unwrapped:
+            return unwrapped
+        unwrapped = next_fh
+
+
 class Interceptor:
     """Intercepts file-io and logs what is going on.
 

--- a/pyfive/utilities.py
+++ b/pyfive/utilities.py
@@ -45,6 +45,38 @@ class Interceptor:
         return self._fh.read(size)
 
 
+class HDF5OffsetWrapper:
+    """Expose an HDF5 file view whose logical offset 0 starts at base_address."""
+
+    def __init__(self, fh, base_address: int):
+        self._fh = fh
+        self.base_address = base_address
+
+    def __getattr__(self, name: str):
+        """Return attributes from the underlying file handle."""
+        return getattr(self._fh, name)
+
+    def seek(self, offset: int, whence: int = 0) -> int:
+        """Seek in the HDF5-relative address space."""
+        if whence == 0:
+            position = self._fh.seek(offset + self.base_address, whence)
+            return position - self.base_address
+        position = self._fh.seek(offset, whence)
+        return position - self.base_address
+
+    def read(self, size: int = -1) -> bytes:
+        """Read from the current HDF5-relative offset."""
+        return self._fh.read(size)
+
+    def tell(self) -> int:
+        """Return the current HDF5-relative file position."""
+        return self._fh.tell() - self.base_address
+
+    def close(self):
+        """Close the underlying file."""
+        self._fh.close()
+
+
 class MetadataBufferingWrapper:
     """
     Wraps a file-like object to eagerly buffer metadata from S3 or remote sources.

--- a/tests/test_attr_datatypes.py
+++ b/tests/test_attr_datatypes.py
@@ -80,8 +80,8 @@ def test_string_scalar_attr_datatypes():
         assert hfile.attrs["string_one"] == b"H"
         assert hfile.attrs["string_two"] == b"Hi"
 
-        assert hfile.attrs["vlen_string"] == "Hello"
-        assert hfile.attrs["vlen_unicode"] == ("Hello" + b"\xc2\xa7".decode("utf-8"))
+        assert hfile.attrs["vlen_string"] == b"Hello"
+        assert hfile.attrs["vlen_unicode"] == b"Hello\xc2\xa7"
 
 
 def test_numeric_array_attr_datatypes():
@@ -109,11 +109,11 @@ def test_string_array_attr_datatypes(attr_datatypes_hdf5):
         assert hfile.attrs["vlen_str_array"].dtype == np.dtype("S6")
 
         # strings
-        assert hfile.attrs["vlen_str_array1"][0] == "Hello"
-        assert hfile.attrs["vlen_str_array1"][1] == "World!"
+        assert hfile.attrs["vlen_str_array1"][0] == b"Hello"
+        assert hfile.attrs["vlen_str_array1"][1] == b"World!"
 
         assert hfile.attrs["vlen_str_array1"].dtype == np.dtype("O")
-        assert hfile.attrs["vlen_str_array1"].dtype.metadata == {"vlen": bytes}
+        assert hfile.attrs["vlen_str_array1"].dtype.metadata["vlen"] is bytes
 
 
 def test_vlen_sequence_attr_datatypes():
@@ -158,7 +158,7 @@ def test_attributes_2(attr_datatypes_hdf5_2):
     ascii = "ascii"
     unicode = "unicodé"
 
-    with pyfive.File(attr_datatypes_hdf5_2) as ds:
+    with pyfive.File(attr_datatypes_hdf5_2, decode_strings=True) as ds:
         foobar = "foobár"
         assert isinstance(ds.attrs["unicode"], str)
         assert ds.attrs["unicode"] == unicode
@@ -238,3 +238,20 @@ def test_attributes_2(attr_datatypes_hdf5_2):
         np.testing.assert_equal(ds.attrs["int_array"], np.arange(10))
         np.testing.assert_equal(ds.attrs["empty_list"], np.array([]))
         np.testing.assert_equal(ds.attrs["empty_array"], np.array([]))
+
+
+def test_attributes_2_default_bytes(attr_datatypes_hdf5_2):
+    with pyfive.File(attr_datatypes_hdf5_2) as ds:
+        assert ds.attrs["unicode"] == "unicodé".encode("utf-8")
+        assert ds.attrs["unicode_0dim"] == "unicodé".encode("utf-8")
+        assert (
+            ds.attrs["unicode_arrary"] == [b"unicod\xc3\xa9", b"foob\xc3\xa1r"]
+        ).all()
+
+        assert ds.attrs["ascii"] == b"ascii"
+        assert ds.attrs["ascii_0dim"] == b"ascii"
+        assert (ds.attrs["ascii_array"] == [b"ascii", b"foobar"]).all()
+
+        assert ds.attrs["bytes"] == b"ascii"
+        assert ds.attrs["bytes_0dim"] == b"ascii"
+        assert (ds.attrs["bytes_array"] == [b"ascii", b"foobar"]).all()

--- a/tests/test_btree_parallel.py
+++ b/tests/test_btree_parallel.py
@@ -15,6 +15,10 @@ DIRNAME = os.path.dirname(__file__)
 DATASET_CHUNKED_HDF5_FILE = os.path.join(DIRNAME, "data", "chunked.hdf5")
 
 
+class _ConnectionTimeoutError(Exception):
+    pass
+
+
 def _build_leaf_node_bytes(*, dims, entries):
     header = struct.pack("<4sBBHQQ", b"TREE", 1, 0, len(entries), 0, 0)
     body = bytearray()
@@ -38,8 +42,8 @@ class _DummyFS:
         self.payload_by_start = payload_by_start
         self.calls = []
 
-    def cat_ranges(self, paths, starts, stops):
-        self.calls.append((paths, starts, stops))
+    def cat_ranges(self, paths, starts, stops, **kwargs):
+        self.calls.append((paths, starts, stops, kwargs))
         return [self.payload_by_start[s] for s in starts]
 
 
@@ -176,7 +180,45 @@ def test_make_btree_fetch_fn_cat_ranges_case():
 
     out = fetch_fn([10, 20], 4)
     assert out == [b"abcd", b"efgh"]
-    assert fs.calls == [(["bucket/file.h5", "bucket/file.h5"], [10, 20], [14, 24])]
+    assert fs.calls == [
+        (
+            ["bucket/file.h5", "bucket/file.h5"],
+            [10, 20],
+            [14, 24],
+            {"on_error": "raise"},
+        )
+    ]
+
+
+def test_make_btree_fetch_fn_cat_ranges_raises_returned_exception():
+    dsid = DatasetID.__new__(DatasetID)
+    dsid.posix = False
+    dsid.set_parallelism(thread_count=0, cat_range_allowed=True, btree_parallel=True)
+
+    timeout = _ConnectionTimeoutError("timed out")
+    fs = _DummyFS({10: timeout})
+    dsid._DatasetID__fh = _WrappedFH(fs, "bucket/file.h5")
+
+    fetch_fn = dsid._make_btree_fetch_fn()
+    assert fetch_fn is not None
+
+    with pytest.raises(_ConnectionTimeoutError, match="timed out"):
+        fetch_fn([10], 4)
+
+
+def test_read_bulk_fsspec_raises_returned_exception():
+    dsid = DatasetID.__new__(DatasetID)
+    timeout = _ConnectionTimeoutError("timed out")
+    fs = _DummyFS({10: timeout})
+    fh = _WrappedFH(fs, "bucket/file.h5")
+
+    storeinfo = type(
+        "StoreInfo", (), {"byte_offset": 10, "size": 4, "filter_mask": 0}
+    )()
+    chunks = [((0,), slice(None), slice(None), storeinfo)]
+
+    with pytest.raises(_ConnectionTimeoutError, match="timed out"):
+        dsid._read_bulk_fsspec(fh, chunks, out=None, dtype=None)
 
 
 def test_make_btree_fetch_fn_pread_case(tmp_path):

--- a/tests/test_earliest.py
+++ b/tests/test_earliest.py
@@ -42,11 +42,11 @@ def test_read_earliest():
 
         # sub-group
         subgroup = grp["subgroup1"]
-        assert subgroup.attrs["attr5"] == "Test"
-        assert isinstance(subgroup.attrs["attr5"], str)
+        assert subgroup.attrs["attr5"] == b"Test"
+        assert isinstance(subgroup.attrs["attr5"], bytes)
 
         dset3 = subgroup["dataset3"]
         assert_array_equal(dset2[:], np.arange(4))
         assert dset3.dtype == np.dtype("<f4")
-        assert dset3.attrs["attr6"] == "Test" + b"\xc2\xa7".decode("utf-8")
-        assert isinstance(dset3.attrs["attr6"], string_type)
+        assert dset3.attrs["attr6"] == b"Test\xc2\xa7"
+        assert isinstance(dset3.attrs["attr6"], bytes)

--- a/tests/test_file_like.py
+++ b/tests/test_file_like.py
@@ -47,15 +47,15 @@ def test_read_latest_fileobj():
 
             # sub-group
             subgroup = grp["subgroup1"]
-            assert subgroup.attrs["attr5"] == "Test"
-            assert isinstance(subgroup.attrs["attr5"], str)
+            assert subgroup.attrs["attr5"] == b"Test"
+            assert isinstance(subgroup.attrs["attr5"], bytes)
 
             dset3 = subgroup["dataset3"]
             assert_array_equal(dset2[:], np.arange(4))
             assert dset3.dtype == np.dtype("<f4")
-            ref_attr6 = "Test" + b"\xc2\xa7".decode("utf-8")
+            ref_attr6 = b"Test\xc2\xa7"
             assert dset3.attrs["attr6"] == ref_attr6
-            assert isinstance(dset3.attrs["attr6"], string_type)
+            assert isinstance(dset3.attrs["attr6"], bytes)
 
 
 def write_compressed_tobytes(file_like):

--- a/tests/test_fillvalue.py
+++ b/tests/test_fillvalue.py
@@ -114,12 +114,16 @@ def test_uninitialized_data(tmp_path):
     make_uninitialized_data_file_nc(tfile)
 
     with pyfive.File(tfile, "r") as pfile:
-        assert np.array_equal(pfile["string"][1], [""] * 4)
+        assert np.array_equal(pfile["string"][1], [b""] * 4)
         assert np.array_equal(pfile["char"][1], [b""] * 4)
         assert np.array_equal(pfile["int32"][1], [-2147483647] * 4)
         assert np.array_equal(pfile["float64"][1], [9.969209968386869e36] * 4)
 
-        assert np.array_equal(pfile["string_2"][1], ["NA"] * 4)
+        assert np.array_equal(pfile["string_2"][1], [b"NA"] * 4)
         assert np.array_equal(pfile["char_2"][1], [b"x"] * 4)
         assert np.array_equal(pfile["int32_2"][1], [999] * 4)
         assert np.array_equal(pfile["float64_2"][1], [999.9] * 4)
+
+    with pyfive.File(tfile, "r", decode_strings=True) as pfile:
+        assert np.array_equal(pfile["string"][1], [""] * 4)
+        assert np.array_equal(pfile["string_2"][1], ["NA"] * 4)

--- a/tests/test_latest.py
+++ b/tests/test_latest.py
@@ -42,11 +42,11 @@ def test_read_latest():
 
         # sub-group
         subgroup = grp["subgroup1"]
-        assert subgroup.attrs["attr5"] == "Test"
-        assert isinstance(subgroup.attrs["attr5"], str)
+        assert subgroup.attrs["attr5"] == b"Test"
+        assert isinstance(subgroup.attrs["attr5"], bytes)
 
         dset3 = subgroup["dataset3"]
         assert_array_equal(dset2[:], np.arange(4))
         assert dset3.dtype == np.dtype("<f4")
-        assert dset3.attrs["attr6"] == "Test" + b"\xc2\xa7".decode("utf-8")
-        assert isinstance(dset3.attrs["attr6"], string_type)
+        assert dset3.attrs["attr6"] == b"Test\xc2\xa7"
+        assert isinstance(dset3.attrs["attr6"], bytes)

--- a/tests/test_matlab.py
+++ b/tests/test_matlab.py
@@ -1,0 +1,12 @@
+import pyfive as p5
+from pathlib import Path
+
+MFILE = Path(__file__).parent / "data" / "Data_20230106_01_014.mat"
+
+
+def test_matlab():
+    """Test user supplied MATLAB file (issue #252)"""
+    with p5.File(MFILE, "r") as f:
+        assert f.userblock_size == 512
+        for ds in f:
+            print(ds)

--- a/tests/test_opaque.py
+++ b/tests/test_opaque.py
@@ -12,6 +12,7 @@ def test_opaque_dataset1_hdf5(name, data):
     # expected to get it right.
 
     (ordinary_data, string_data, opdata) = data
+    string_data_bytes = np.array([value.encode("utf-8") for value in string_data])
 
     with h5py.File(name, "r") as f:
         dset = f["opaque_datetimes"]
@@ -27,7 +28,7 @@ def test_opaque_dataset1_hdf5(name, data):
         assert_array_equal(dset[...], opdata)
 
         # make sure the other things are fine
-        assert_array_equal(hfile["string_data"][...], string_data)
+        assert_array_equal(hfile["string_data"][...], string_data_bytes)
         assert_array_equal(hfile["ordinary_data"][...], ordinary_data)
 
         # check the dtype interrogation functions
@@ -49,6 +50,9 @@ def test_opaque_dataset1_hdf5(name, data):
 
         with pytest.raises(TypeError):
             pyfive.check_dtype(fred=1, jane=2)
+
+    with pyfive.File(name, decode_strings=True) as hfile:
+        assert_array_equal(hfile["string_data"][...], string_data)
 
 
 def test_opaque_dataset2_fixed(really_opaque):

--- a/tests/test_vlen_str.py
+++ b/tests/test_vlen_str.py
@@ -169,6 +169,17 @@ def test_vlen_string_hdf5(tmp_path):
         ds2 = hfile["var_len_str_fv"][:]
         print(ds1)
         print(ds2)
+        assert np.array_equal(
+            ds1[:2], [value.encode("utf-8") for value in vlen_strings]
+        )
+        assert np.array_equal(
+            ds2[:2], [value.encode("utf-8") for value in vlen_strings]
+        )
+        assert ds2[3] == b"this really fills the data"
+
+    with pyfive.File(our_file, decode_strings=True) as hfile:
+        ds1 = hfile["var_len_str"][:]
+        ds2 = hfile["var_len_str_fv"][:]
         assert np.array_equal(ds1[:2], vlen_strings)
         assert np.array_equal(ds2[:2], vlen_strings)
         assert ds2[3] == "this really fills the data"
@@ -212,6 +223,10 @@ def test_vlen_string_nc2(tmp_path):
 
     with pyfive.File(tfile) as hfile:
         ds1 = hfile["months"][:].tolist()
+        assert np.array_equal(m_array_bytes, ds1)
+
+    with pyfive.File(tfile, decode_strings=True) as hfile:
+        ds1 = hfile["months"][:].tolist()
         assert np.array_equal(m_array, ds1)
 
 
@@ -219,7 +234,7 @@ def test_pathological_strings(tmp_path):
     tfile = tmp_path / "test_strings.nc"
     validation = make_pathological_nc(tfile)
     warnings.warn("Validation of variable length strings assumes h5py is wrong")
-    with pyfive.File(tfile) as pfile:
+    with pyfive.File(tfile, decode_strings=True) as pfile:
         with h5py.File(tfile) as hfile:
             for k, v in validation.items():
                 hdata = hfile[k][...]
@@ -271,3 +286,48 @@ def test_vlen_contiguous_chunked(tmp_path):
             (slice(0, 2), slice(0, 2)),
         ):
             assert np.array_equal(contiguous[index], chunked[index])
+
+
+def test_issue228(tmp_path):
+    """Test unicode variable-length strings can be decoded on request."""
+    input_strings = ["foó", "bár", "baź"]
+    tfile = tmp_path / "issue228.h5"
+
+    with h5py.File(tfile, "w") as hfile:
+        dtype = h5py.string_dtype("utf-8")
+        dataset = hfile.create_dataset("x", (len(input_strings),), dtype=dtype)
+        dataset[...] = input_strings
+
+    with h5py.File(tfile, "r") as hfile:
+        dataset = hfile["x"]
+        assert h5py.check_dtype(vlen=dataset.dtype) is str
+        assert dataset.asstr()[...].tolist() == input_strings
+
+    with pyfive.File(tfile, decode_strings=True) as hfile:
+        dataset = hfile["x"]
+        string_info = pyfive.check_dtype(vlen=dataset.dtype)
+        assert string_info is not None
+        assert string_info.encoding == "utf-8"
+        assert string_info.length is None
+        assert dataset[...].tolist() == input_strings
+
+
+def test_issue228_default_read_matches_h5py(tmp_path):
+    """Default vlen string reads should match h5py's byte-oriented behavior."""
+    input_strings = ["foó", "bár", "baź"]
+    input_bytes = [value.encode("utf-8") for value in input_strings]
+    tfile = tmp_path / "issue228_default_read.h5"
+
+    with h5py.File(tfile, "w") as hfile:
+        dtype = h5py.string_dtype("utf-8")
+        dataset = hfile.create_dataset("x", (len(input_strings),), dtype=dtype)
+        dataset[...] = input_strings
+
+    with h5py.File(tfile, "r") as hfile:
+        h5py_data = hfile["x"][...].tolist()
+
+    with pyfive.File(tfile) as hfile:
+        pyfive_data = hfile["x"][...].tolist()
+
+    assert h5py_data == input_bytes
+    assert pyfive_data == input_bytes


### PR DESCRIPTION
## Description

#252 exposed a problem with our superblock handling. The HDF5 spec allows a user block in front of the HDF5 itself, and HDF5 implementations should look for the superblock at 0, and then at powers of 2 greater than 512 bytes.  This means that if we don't find a superblock at offset zero, we have to go looking for where it might be before rejecting the file as not being an HDF5 file.

Closes #252, #249 and #228.

## Checklist

- [ ] This pull request has a descriptive title and labels
- [ ] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- [ ] Unit tests have been added (if codecov test fails)
- [ ] Any changed dependencies have been added or removed correctly (if need be)
- [ ] If you are working on the documentation, please ensure the [current build](https://app.readthedocs.org/projects/pyfive/builds/) passes
- [ ] All tests pass
