### PR TITLE
Fix reading global heap

### DIFF
--- a/pyfive/misc_low_level.py
+++ b/pyfive/misc_low_level.py
@@ -158,15 +158,22 @@ class GlobalHeap(object):
         if self._objects is None:
             self._objects = OrderedDict()
             offset = 0
-            while offset < len(self.heap_data):
+            # Note: Need to add 16 to the offset to ensure at least 16
+            #       bytes remain in the buffer to unpack a complete
+            #       GLOBAL_HEAP_OBJECT header, preventing struct.error
+            #       on trailing padding (< 16B). See
+            #       https://github.com/NCAS-CMS/pyfive/issues/259
+            while offset + 16 <= len(self.heap_data):
                 info = _unpack_struct_from(GLOBAL_HEAP_OBJECT, self.heap_data, offset)
                 if info["object_index"] == 0:
                     break
+
                 offset += GLOBAL_HEAP_OBJECT_SIZE
                 fmt = "<" + str(info["object_size"]) + "s"
                 obj_data = struct.unpack_from(fmt, self.heap_data, offset)[0]
                 self._objects[info["object_index"]] = obj_data
                 offset += _padded_size(info["object_size"])
+
         return self._objects
 
 


### PR DESCRIPTION
Closed in favour of #261
----

## Fix reading global heap

Closes issue 259 

No unit test has been provided, because I found it hard to recreate the conditions in a reliable way! However, the two use cases from the issue now work, and all existing tests pass, so I was going to leave it at that. Can try harder to make a units test, if you like ...

## Before you get started

- [x] [☝ Create an issue](https://github.com/NCAS-CMS/pyfive/issues) to discuss what you are going to do

## Checklist

- [x] This pull request has a descriptive title and labels
- [x] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- [x] Unit tests have been added (if codecov test fails)
- [x] Any changed dependencies have been added or removed correctly (if need be)
- [x] If you are working on the documentation, please ensure the [current build](https://app.readthedocs.org/projects/pyfive/builds/) passes
- [x] All tests pass
