### PR TITLE
Fix Global Heap over-read on sub-header trailing padding

### DIFF
--- a/pyfive/misc_low_level.py
+++ b/pyfive/misc_low_level.py
@@ -158,7 +158,12 @@ class GlobalHeap(object):
         if self._objects is None:
             self._objects = OrderedDict()
             offset = 0
-            while offset < len(self.heap_data):
+            # Only read an object when a full GLOBAL_HEAP_OBJECT header fits in the
+            # remaining bytes. The collection's trailing free space is marked by an
+            # object with index 0, but libhdf5 writes that marker only when at least one
+            # 16-byte object header fits. A smaller remainder (e.g. 8 bytes) is just
+            # padding.
+            while offset + GLOBAL_HEAP_OBJECT_SIZE <= len(self.heap_data):
                 info = _unpack_struct_from(GLOBAL_HEAP_OBJECT, self.heap_data, offset)
                 if info["object_index"] == 0:
                     break

--- a/tests/test_global_heap.py
+++ b/tests/test_global_heap.py
@@ -1,0 +1,66 @@
+""" Unit tests for pyfive's Global Heap collection reader. """
+import io
+import struct
+
+import pytest
+from pyfive.misc_low_level import GLOBAL_HEAP_HEADER_SIZE, GlobalHeap
+
+
+def build_global_heap_collection(objects, trailing_pad=0):
+    """ Return the bytes of a valid HDF5 Global Heap collection (GCOL).
+
+    ``objects`` is a list of ``(object_index, object_data)`` pairs. Each object's
+    data is padded to an 8-byte boundary, as libhdf5 writes it. ``trailing_pad`` is
+    the number of unused free-space bytes appended after the last object. A pad
+    smaller than one 16-byte object header cannot hold the index-0 free-space marker
+    and is just padding.
+    """
+    body = b""
+    for index, data in objects:
+        header = struct.pack("<HHIQ", index, 1, 0, len(data))
+        padded = data + b"\x00" * ((-len(data)) % 8)
+        body += header + padded
+    body += b"\x00" * trailing_pad
+
+    collection_size = GLOBAL_HEAP_HEADER_SIZE + len(body)
+    gcol_header = (
+        b"GCOL" + struct.pack("<B", 1) + b"\x00\x00\x00" + struct.pack("<Q", collection_size)
+    )
+    return gcol_header + body
+
+
+def read_objects(raw):
+    return GlobalHeap(io.BytesIO(raw), 0).objects
+
+
+def test_trailing_padding_smaller_than_header():
+    """ Free space of < 16 bytes at the end must not be read as an object. """
+    raw = build_global_heap_collection([(1, b"hello"), (2, b"abc")], trailing_pad=8)
+    assert read_objects(raw) == {1: b"hello", 2: b"abc"}
+
+
+def test_explicit_free_space_terminator():
+    """ An index-0 free-space object still stops iteration cleanly. """
+    body = (
+        struct.pack("<HHIQ", 1, 1, 0, 5) + b"hello" + b"\x00" * 3
+        + struct.pack("<HHIQ", 0, 0, 0, 0)
+    )
+    collection_size = GLOBAL_HEAP_HEADER_SIZE + len(body)
+    raw = (
+        b"GCOL" + struct.pack("<B", 1) + b"\x00\x00\x00"
+        + struct.pack("<Q", collection_size) + body
+    )
+    assert read_objects(raw) == {1: b"hello"}
+
+
+def test_collection_exactly_full():
+    """ No trailing bytes: every object is parsed and the loop ends at the buffer end. """
+    raw = build_global_heap_collection([(1, b"hello"), (2, b"abcdefgh")], trailing_pad=0)
+    assert read_objects(raw) == {1: b"hello", 2: b"abcdefgh"}
+
+
+@pytest.mark.parametrize("pad", [1, 4, 8, 15])
+def test_sub_header_trailing_pad(pad):
+    """ Any trailing pad shorter than one object header is tolerated. """
+    raw = build_global_heap_collection([(7, b"payload")], trailing_pad=pad)
+    assert read_objects(raw) == {7: b"payload"}

--- a/tests/test_global_heap.py
+++ b/tests/test_global_heap.py
@@ -1,4 +1,5 @@
-""" Unit tests for pyfive's Global Heap collection reader. """
+"""Unit tests for pyfive's Global Heap collection reader."""
+
 import io
 import struct
 
@@ -7,7 +8,7 @@ from pyfive.misc_low_level import GLOBAL_HEAP_HEADER_SIZE, GlobalHeap
 
 
 def build_global_heap_collection(objects, trailing_pad=0):
-    """ Return the bytes of a valid HDF5 Global Heap collection (GCOL).
+    """Return the bytes of a valid HDF5 Global Heap collection (GCOL).
 
     ``objects`` is a list of ``(object_index, object_data)`` pairs. Each object's
     data is padded to an 8-byte boundary, as libhdf5 writes it. ``trailing_pad`` is
@@ -24,7 +25,10 @@ def build_global_heap_collection(objects, trailing_pad=0):
 
     collection_size = GLOBAL_HEAP_HEADER_SIZE + len(body)
     gcol_header = (
-        b"GCOL" + struct.pack("<B", 1) + b"\x00\x00\x00" + struct.pack("<Q", collection_size)
+        b"GCOL"
+        + struct.pack("<B", 1)
+        + b"\x00\x00\x00"
+        + struct.pack("<Q", collection_size)
     )
     return gcol_header + body
 
@@ -34,33 +38,40 @@ def read_objects(raw):
 
 
 def test_trailing_padding_smaller_than_header():
-    """ Free space of < 16 bytes at the end must not be read as an object. """
+    """Free space of < 16 bytes at the end must not be read as an object."""
     raw = build_global_heap_collection([(1, b"hello"), (2, b"abc")], trailing_pad=8)
     assert read_objects(raw) == {1: b"hello", 2: b"abc"}
 
 
 def test_explicit_free_space_terminator():
-    """ An index-0 free-space object still stops iteration cleanly. """
+    """An index-0 free-space object still stops iteration cleanly."""
     body = (
-        struct.pack("<HHIQ", 1, 1, 0, 5) + b"hello" + b"\x00" * 3
+        struct.pack("<HHIQ", 1, 1, 0, 5)
+        + b"hello"
+        + b"\x00" * 3
         + struct.pack("<HHIQ", 0, 0, 0, 0)
     )
     collection_size = GLOBAL_HEAP_HEADER_SIZE + len(body)
     raw = (
-        b"GCOL" + struct.pack("<B", 1) + b"\x00\x00\x00"
-        + struct.pack("<Q", collection_size) + body
+        b"GCOL"
+        + struct.pack("<B", 1)
+        + b"\x00\x00\x00"
+        + struct.pack("<Q", collection_size)
+        + body
     )
     assert read_objects(raw) == {1: b"hello"}
 
 
 def test_collection_exactly_full():
-    """ No trailing bytes: every object is parsed and the loop ends at the buffer end. """
-    raw = build_global_heap_collection([(1, b"hello"), (2, b"abcdefgh")], trailing_pad=0)
+    """No trailing bytes: every object is parsed and the loop ends at the buffer end."""
+    raw = build_global_heap_collection(
+        [(1, b"hello"), (2, b"abcdefgh")], trailing_pad=0
+    )
     assert read_objects(raw) == {1: b"hello", 2: b"abcdefgh"}
 
 
 @pytest.mark.parametrize("pad", [1, 4, 8, 15])
 def test_sub_header_trailing_pad(pad):
-    """ Any trailing pad shorter than one object header is tolerated. """
+    """Any trailing pad shorter than one object header is tolerated."""
     raw = build_global_heap_collection([(7, b"payload")], trailing_pad=pad)
     assert read_objects(raw) == {7: b"payload"}


### PR DESCRIPTION
## Description

`GlobalHeap.objects` looped `while offset < len(self.heap_data)`, so it entered the loop with fewer than a full 16-byte `GLOBAL_HEAP_OBJECT` header remaining and then over-read the buffer. A collection's trailing free space is marked by an object with index 0, but libhdf5 writes that marker only when at least one 16-byte object header fits. When the remainder is smaller it is undefined padding.

Add `tests/test_global_heap.py`, which builds raw GCOL collections in memory and reads them through `GlobalHeap`, deterministically reproducing the crash (a <16-byte trailing pad) and covering the index-0 terminator and exactly-full cases.

Closes #259.

## Checklist

- [x] This pull request has a descriptive title and labels
- [x] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- [x] Unit tests have been added (if codecov test fails)
- [x] All tests pass
