### PR TITLE
Issue264 - Fixing non-standard shuffle/filter order operations

### DIFF
--- a/pyfive/btree.py
+++ b/pyfive/btree.py
@@ -283,22 +283,21 @@ class BTreeV1RawDataChunks(BTreeV1):
                 chunk_buffer = zlib.decompress(chunk_buffer)
             elif filter_id == SHUFFLE_FILTER:
                 buffer_size = len(chunk_buffer)
-                if buffer_size % itemsize != 0:
-                    if (buffer_size - 4) % itemsize == 0:
-                        chunk_buffer = chunk_buffer[:-4]
-                        buffer_size = len(chunk_buffer)
-                    else:
-                        raise ValueError(
-                            "shuffle filter length mismatch: "
-                            f"len={buffer_size}, itemsize={itemsize}"
-                        )
-                unshuffled_buffer = bytearray(buffer_size)
-                step = buffer_size // itemsize
+                # The HDF5 shuffle filter only operates on the largest prefix
+                # of the buffer that is an exact multiple of itemsize; any
+                # trailing remainder bytes (e.g. from a filter applied before
+                # shuffle in the pipeline, such as fletcher32) are left
+                # unshuffled and simply copied through unchanged.
+                remainder = buffer_size % itemsize
+                main_size = buffer_size - remainder
+                tail = chunk_buffer[main_size:]
+                unshuffled_buffer = bytearray(main_size)
+                step = main_size // itemsize
                 for j in range(itemsize):
                     start = j * step
                     end = (j + 1) * step
                     unshuffled_buffer[j::itemsize] = chunk_buffer[start:end]
-                chunk_buffer = unshuffled_buffer
+                chunk_buffer = bytes(unshuffled_buffer) + tail
             elif filter_id == FLETCH32_FILTER:
                 cls._verify_fletcher32(chunk_buffer)
                 # strip off 4-byte checksum from end of buffer

--- a/pyfive/btree.py
+++ b/pyfive/btree.py
@@ -270,10 +270,11 @@ class BTreeV1RawDataChunks(BTreeV1):
     def _filter_chunk(cls, chunk_buffer, filter_mask, filter_pipeline, itemsize):
         """Apply decompression filters to a chunk of data."""
         num_filters = len(filter_pipeline)
-        for i, pipeline_entry in enumerate(filter_pipeline[::-1]):
-            # A filter is skipped is the bit corresponding to its index in the
-            # pipeline is set in filter_mask
-            filter_index = num_filters - i - 1  # 0 to num_filters - 1
+        for filter_index in range(num_filters - 1, -1, -1):
+            pipeline_entry = filter_pipeline[filter_index]
+
+            # A filter is skipped if the bit corresponding to its index in the
+            # pipeline is set in filter_mask.
             if filter_mask & (1 << filter_index):
                 continue
 
@@ -282,6 +283,15 @@ class BTreeV1RawDataChunks(BTreeV1):
                 chunk_buffer = zlib.decompress(chunk_buffer)
             elif filter_id == SHUFFLE_FILTER:
                 buffer_size = len(chunk_buffer)
+                if buffer_size % itemsize != 0:
+                    if (buffer_size - 4) % itemsize == 0:
+                        chunk_buffer = chunk_buffer[:-4]
+                        buffer_size = len(chunk_buffer)
+                    else:
+                        raise ValueError(
+                            "shuffle filter length mismatch: "
+                            f"len={buffer_size}, itemsize={itemsize}"
+                        )
                 unshuffled_buffer = bytearray(buffer_size)
                 step = buffer_size // itemsize
                 for j in range(itemsize):

--- a/tests/test_swift.py
+++ b/tests/test_swift.py
@@ -1,0 +1,41 @@
+import h5py
+import numpy as np
+from numpy.testing import assert_array_equal
+
+import pyfive
+
+
+def test_swift_filter_order(tmp_path):
+    path = tmp_path / "swift_filter_order.h5"
+    data = np.arange(512, dtype="<i8")
+
+    # Build the pipeline in SWIFT's order via the low-level API.
+    dcpl = h5py.h5p.create(h5py.h5p.DATASET_CREATE)
+    dcpl.set_chunk((512,))
+    dcpl.set_fletcher32()
+    dcpl.set_shuffle()
+    dcpl.set_deflate(4)
+
+    fid = h5py.h5f.create(str(path).encode(), h5py.h5f.ACC_TRUNC)
+    dsid = h5py.h5d.create(
+        fid,
+        b"d",
+        h5py.h5t.py_create(data.dtype, logical=True),
+        h5py.h5s.create_simple((512,)),
+        dcpl=dcpl,
+    )
+    dsid.write(h5py.h5s.ALL, h5py.h5s.ALL, data)
+    del dsid
+    fid.close()
+
+    with h5py.File(path, "r") as f:
+        plist = f["d"].id.get_create_plist()
+        assert [plist.get_filter(i)[0] for i in range(plist.get_nfilters())] == [
+            3,
+            2,
+            1,
+        ]
+        assert_array_equal(f["d"][...], data)
+
+    with pyfive.File(path) as f:
+        assert_array_equal(f["d"][...], data)


### PR DESCRIPTION
## Description

This pull request handles non-standard shuffle/filter operations. While the original code did things in the right order, it turns out that different orders mean that the shuffle step is seeing a different length buffer. In this situation the chunk buffer reaching the shuffle-undo step isn't always an exact multiple of `itemsize`. The HDF5 C library handles this by shuffling only the largest itemsize-aligned prefix and passing any trailing remainder bytes through unchanged, which is now what we do.

Closes #264

## Checklist

- [x] This pull request has a descriptive title and labels
- [x] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- [x] Unit tests have been added (if codecov test fails)
- [x] Any changed dependencies have been added or removed correctly (if need be)
- [x] If you are working on the documentation, please ensure the [current build](https://app.readthedocs.org/projects/pyfive/builds/) passes
- [ ] All tests pass
