### PR TITLE
Make Global Heaps cache on file not on dataobjects

### DIFF
--- a/pyfive/dataobjects.py
+++ b/pyfive/dataobjects.py
@@ -57,7 +57,7 @@ class DataObjects(object):
     HDF5 DataObjects.
     """
 
-    def __init__(self, fh, offset, order="C", decode_strings=False):
+    def __init__(self, fh, offset, order="C", decode_strings=False, global_heaps=None):
         """initalize."""
         # Log file handle info for diagnostics
         actual_fh = unwrap_file_handle(fh)
@@ -87,7 +87,7 @@ class DataObjects(object):
         self.msgs = msgs
         self.msg_data = msg_data
         self.offset = offset
-        self._global_heaps = {}
+        self._global_heaps = {} if global_heaps is None else global_heaps
         self._header = header
 
         # cached attributes

--- a/pyfive/h5d.py
+++ b/pyfive/h5d.py
@@ -269,6 +269,7 @@ class DatasetID(ChunkRead):
         dataobject: "DataObjects",  # type: ignore[name-defined]  # noqa: F821
         noindex: bool = False,
         pseudo_chunking_size_MB: int = 4,
+        global_heaps: dict | None = None,
     ) -> None:
         """
         Instantiated with the ``pyfive`` ``datasetdataobject``, we copy and cache everything
@@ -328,12 +329,9 @@ class DatasetID(ChunkRead):
         self._decode_strings = dataobject.decode_strings
         self.set_parallelism()
 
-        # experimental code. We need to find out whether or not this
-        # is unnecessary duplication. At the moment it seems best for
-        # each variable to have it's own copy of those needed for
-        # data access. Though that's clearly not optimal if they include
-        # other data. To be determined.
-        self._global_heaps: dict = {}
+        # Share the per-file global-heap cache so all datasets/attrs that point into
+        # the same GCOL reuse the same parsed collection instead of re-reading it.
+        self._global_heaps: dict = {} if global_heaps is None else global_heaps
 
         self._msg_offset, self.layout_class, self.property_offset = (
             dataobject.get_id_storage_params()

--- a/pyfive/high_level.py
+++ b/pyfive/high_level.py
@@ -140,7 +140,13 @@ class Group(Mapping):
         if dataobjs.is_dataset:
             if additional_obj != ".":
                 raise KeyError("%s is a dataset, not a group" % (obj_name))
-            return Dataset(obj_name, DatasetID(dataobjs, noindex=noindex), self)
+            return Dataset(
+                obj_name,
+                DatasetID(
+                    dataobjs, noindex=noindex, global_heaps=dataobjs._global_heaps
+                ),
+                self,
+            )
 
         try:
             # if true, this may well raise a NotImplementedError, if so, we need
@@ -318,6 +324,7 @@ class File(Group):
             logical_superblock_offset = superblock_offset
         self._superblock = SuperBlock(self._fh, logical_superblock_offset)
         self._dataobjects_cache: dict = {}
+        self._global_heaps: dict = {}
         offset = self._superblock.offset_to_dataobjects
         dataobjects = self._get_dataobjects(offset)
 
@@ -378,6 +385,7 @@ class File(Group):
             self._fh,
             obj_addr,
             decode_strings=self.decode_strings,
+            global_heaps=self._global_heaps,
         )
         self._dataobjects_cache[obj_addr] = dataobjects
         return dataobjects

--- a/tests/test_global_heap.py
+++ b/tests/test_global_heap.py
@@ -3,7 +3,9 @@
 import io
 import struct
 
+import h5py
 import pytest
+import pyfive
 from pyfive.misc_low_level import GLOBAL_HEAP_HEADER_SIZE, GlobalHeap
 
 
@@ -68,6 +70,42 @@ def test_collection_exactly_full():
         [(1, b"hello"), (2, b"abcdefgh")], trailing_pad=0
     )
     assert read_objects(raw) == {1: b"hello", 2: b"abcdefgh"}
+
+
+def make_shared_global_heap_file(tmp_path):
+    """Create a file where many datasets and attrs point into the same GCOL."""
+    path = tmp_path / "shared_global_heap.h5"
+    shared = ["alpha", "beta", "gamma"]
+    with h5py.File(path, "w") as f:
+        for i in range(5):
+            ds = f.create_dataset(f"ds{i}", (2,), dtype=h5py.special_dtype(vlen=str))
+            ds[:] = [shared[0], shared[1]]
+            ds.attrs["row"] = shared
+            ds.attrs["other"] = shared
+    return path
+
+
+def test_global_heap_is_cached_per_file(tmp_path, monkeypatch):
+    """A GCOL referenced by many datasets should be loaded only once per file."""
+    path = make_shared_global_heap_file(tmp_path)
+    original = pyfive.misc_low_level.GlobalHeap
+    calls = []
+
+    def tracked(fh, offset):
+        calls.append(offset)
+        return original(fh, offset)
+
+    monkeypatch.setattr(pyfive.misc_low_level, "GlobalHeap", tracked)
+    monkeypatch.setattr(pyfive.dataobjects, "GlobalHeap", tracked)
+
+    with pyfive.File(path) as hfile:
+        for name in hfile:
+            _ = hfile[name].attrs
+            _ = hfile[name][:]
+
+    assert len(calls) == 1
+    assert len(set(calls)) == 1
+    assert len(hfile._global_heaps) == 1
 
 
 @pytest.mark.parametrize("pad", [1, 4, 8, 15])


### PR DESCRIPTION

Optimise the extraction of global heaps to avoid repeating global heap loading for every variable.

## Description

Adds a test and makes the global heap cache resident on the file.

Closes #262 

## Checklist

- [ ] This pull request has a descriptive title and labels
- [ ] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- [ ] Unit tests have been added (if codecov test fails)
- [ ] Any changed dependencies have been added or removed correctly (if need be)
- [ ] If you are working on the documentation, please ensure the [current build](https://app.readthedocs.org/projects/pyfive/builds/) passes
- [ ] All tests pass
