### PR TITLE
Added more informative errors when trying to read netcdf3

### DIFF
--- a/pyfive/high_level.py
+++ b/pyfive/high_level.py
@@ -340,6 +340,13 @@ class File(Group):
                 if fh.read(len(FORMAT_SIGNATURE)) == FORMAT_SIGNATURE:
                     return offset
                 offset = 512 if offset == 0 else offset * 2
+
+            # Not an HDF5 file - check if it's a classic NetCDF3 file instead,
+            # so we can raise a more specific/useful error.
+            fh.seek(0)
+            magic = fh.read(4)
+            if magic[:3] == b"CDF" and magic[3:4] in (b"\x01", b"\x02", b"\x05"):
+                raise InvalidHDF5File("NetCDF3 files are not supported")
         finally:
             fh.seek(original_offset)
 

--- a/pyfive/misc_low_level.py
+++ b/pyfive/misc_low_level.py
@@ -43,8 +43,6 @@ class SuperBlock(object):
             )
 
         # verify contents
-        if contents["format_signature"] != FORMAT_SIGNATURE:
-            raise InvalidHDF5File("Incorrect file signature")
         if contents["offset_size"] != 8 or contents["length_size"] != 8:
             raise NotImplementedError("File uses none 64-bit addressing")
         self.version = contents["superblock_version"]


### PR DESCRIPTION
## Description

The title says it all 

Closes #263

## Checklist

- [x] This pull request has a descriptive title and labels
- [x] This pull request has a minimal description (most was discussed in the issue, but a two-liner description is still desirable)
- [x] Unit tests have been added (if codecov test fails)
- [x] Any changed dependencies have been added or removed correctly (if need be)
- [x] If you are working on the documentation, please ensure the [current build](https://app.readthedocs.org/projects/pyfive/builds/) passes
- [ ] All tests pass
